### PR TITLE
IT-3317 Setting default for caching auth token to one day

### DIFF
--- a/README.md
+++ b/README.md
@@ -185,6 +185,7 @@ parameters:
   OidcTokenEndpoint: 'https://qtg2zn2bbf.execute-api.us-east-1.amazonaws.com/token'
   OidcUserInfoEndpoint: 'https://repo-prod.prod.sagebase.org/auth/v1/oauth2/userinfo'
   OidcClientId: '100050'
+  SessionTimeout: 3600
   KmsDecryptPolicyArn: !stack_output_external sc-kms-key::KmsDecryptPolicyArn
 ```
 

--- a/ruler/app.py
+++ b/ruler/app.py
@@ -48,7 +48,8 @@ def get_envvars():
     'OIDC_AUTHORIZATION_ENDPOINT',
     'OIDC_TOKEN_ENDPOINT',
     'OIDC_USER_INFO_ENDPOINT',
-    'OIDC_CLIENT_ID'
+    'OIDC_CLIENT_ID',
+    'OIDC_SESSION_TIMEOUT'
   ]
   return get_variables(os.getenv, env_var_names, MISSING_ENVIRONMENT_VARIABLE_MESSAGE)
 
@@ -105,7 +106,7 @@ def create(event, context):
 
   # get variables from lambda properties and environment
   instance_id, target_group_arn, listener_arn = get_properties(event)
-  oidc_client_secret_key_name, oidc_issuer, oidc_auth_endpoint, oidc_token_endpoint, oidc_user_info_endpoint, oidc_client_id  = get_envvars()
+  oidc_client_secret_key_name, oidc_issuer, oidc_auth_endpoint, oidc_token_endpoint, oidc_user_info_endpoint, oidc_client_id, session_timeout  = get_envvars()
 
   # get oidc client secret from ssm
   client_secret = get_client_key(oidc_client_secret_key_name)
@@ -142,7 +143,7 @@ def create(event, context):
               "claims": "{\"id_token\":{\"userid\":{\"essential\":true}},\"userinfo\":{\"userid\":{\"essential\":true}}}"
             },
             "OnUnauthenticatedRequest": "authenticate",
-            "SessionTimeout": 3600
+            "SessionTimeout": session_timeout
           },
           "Order": 1
         },

--- a/ruler/app.py
+++ b/ruler/app.py
@@ -141,7 +141,8 @@ def create(event, context):
             "AuthenticationRequestExtraParams": {
               "claims": "{\"id_token\":{\"userid\":{\"essential\":true}},\"userinfo\":{\"userid\":{\"essential\":true}}}"
             },
-            "OnUnauthenticatedRequest": "authenticate"
+            "OnUnauthenticatedRequest": "authenticate",
+            "SessionTimeout": 3600
           },
           "Order": 1
         },

--- a/template.yaml
+++ b/template.yaml
@@ -25,6 +25,10 @@ Parameters:
   KmsDecryptPolicyArn:
     Description: 'The ARN of the KMS decryption policy'
     Type: String
+  SessionTimeout:
+    Description: 'The duration for which an access token is kept before retrieving a new one'
+    Type: Number
+    Default: 3600
 
 Globals:
   Function:
@@ -46,6 +50,7 @@ Resources:
           OIDC_TOKEN_ENDPOINT: !Ref OidcTokenEndpoint
           OIDC_USER_INFO_ENDPOINT: !Ref OidcUserInfoEndpoint
           OIDC_CLIENT_ID: !Ref OidcClientId
+          SESSION_TIMEOUT: !Ref SessionTimeout
 
   ALBListenerRuleFunctionRole:
     Type: AWS::IAM::Role

--- a/tests/unit/test_create.py
+++ b/tests/unit/test_create.py
@@ -24,7 +24,8 @@ class TestCreate(unittest.TestCase):
     'auth-endpoint',
     'token-endpoint',
     'user-info-endpoint',
-    'client-id'
+    'client-id',
+    3600
   ]
 
 

--- a/tests/unit/test_get_variables.py
+++ b/tests/unit/test_get_variables.py
@@ -40,7 +40,8 @@ class TestGetVariables(unittest.TestCase):
     'OIDC_AUTHORIZATION_ENDPOINT',
     'OIDC_TOKEN_ENDPOINT',
     'OIDC_USER_INFO_ENDPOINT',
-    'OIDC_CLIENT_ID'
+    'OIDC_CLIENT_ID',
+    'OIDC_SESSION_TIMEOUT'
     ]
 
     vals = list(range(len(env_var_names)))


### PR DESCRIPTION
While testing 'passwordless login' to the Jupyter notebook in IT-3317, we found that the Synapse access token available in the notebook is past its one day expiration.  The token is obtained from Synapse by the ALB when the user connects to the notebook, however it's keeping it for up to seven days. The [doc's](https://docs.aws.amazon.com/elasticloadbalancing/latest/application/listener-authenticate-users.html) say:

> By default, the SessionTimeout field is set to 7 days. If you want shorter sessions, you can configure a session timeout as short as 1 second. For more information, see Session timeout.

So this PR changes the timeout to just one day, forcing the ALB to get a new token when the cached one expires.