### PR TITLE
OIDC_SESSION_TIMEOUT should just be SESSION_TIMEOUT

### DIFF
--- a/ruler/app.py
+++ b/ruler/app.py
@@ -49,7 +49,7 @@ def get_envvars():
     'OIDC_TOKEN_ENDPOINT',
     'OIDC_USER_INFO_ENDPOINT',
     'OIDC_CLIENT_ID',
-    'OIDC_SESSION_TIMEOUT'
+    'SESSION_TIMEOUT'
   ]
   return get_variables(os.getenv, env_var_names, MISSING_ENVIRONMENT_VARIABLE_MESSAGE)
 

--- a/tests/unit/test_get_variables.py
+++ b/tests/unit/test_get_variables.py
@@ -41,7 +41,7 @@ class TestGetVariables(unittest.TestCase):
     'OIDC_TOKEN_ENDPOINT',
     'OIDC_USER_INFO_ENDPOINT',
     'OIDC_CLIENT_ID',
-    'OIDC_SESSION_TIMEOUT'
+    'SESSION_TIMEOUT'
     ]
 
     vals = list(range(len(env_var_names)))


### PR DESCRIPTION
Fixing a mistake: OIDC_SESSION_TIMEOUT should just be SESSION_TIMEOUT, to match the property name in `template.yaml`.