### PR TITLE
convert string Session-Timeout env var to int

### DIFF
--- a/ruler/app.py
+++ b/ruler/app.py
@@ -143,7 +143,7 @@ def create(event, context):
               "claims": "{\"id_token\":{\"userid\":{\"essential\":true}},\"userinfo\":{\"userid\":{\"essential\":true}}}"
             },
             "OnUnauthenticatedRequest": "authenticate",
-            "SessionTimeout": session_timeout
+            "SessionTimeout": int(session_timeout)
           },
           "Order": 1
         },

--- a/template.yaml
+++ b/template.yaml
@@ -26,7 +26,7 @@ Parameters:
     Description: 'The ARN of the KMS decryption policy'
     Type: String
   SessionTimeout:
-    Description: 'The duration for which an access token is kept before retrieving a new one'
+    Description: 'The duration (in seconds) for which an access token is kept before retrieving a new one'
     Type: Number
     Default: 3600
 

--- a/tests/unit/test_create.py
+++ b/tests/unit/test_create.py
@@ -25,7 +25,7 @@ class TestCreate(unittest.TestCase):
     'token-endpoint',
     'user-info-endpoint',
     'client-id',
-    3600
+    '3600'
   ]
 
 


### PR DESCRIPTION
CF turns numbers into strings, as explained [here](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/parameters-section-structure.html):

> Number
> An integer or float. AWS CloudFormation validates the parameter value as a number; however, when you use the parameter elsewhere in your template (for example, by using the Ref intrinsic function), the parameter value becomes a string.

This means that when `app.py` retrieves the env var, `SESSION_TIMEOUT`, it gets a string, not an int, and then when it tries to pass it to `AuthenticateOidcConfig` we get:

> Received response status [FAILED] from custom resource. Message returned: Parameter validation failed: Invalid type for parameter Actions[0].AuthenticateOidcConfig.SessionTimeout, value: 3600, type: <class 'str'>, valid types: <class 'int'> 

S we have to explicitly convrt back to an int in Python with `int()`. 