### PR TITLE
make session cookies unique for Notebook instances

### DIFF
--- a/README.md
+++ b/README.md
@@ -185,6 +185,7 @@ parameters:
   OidcTokenEndpoint: 'https://qtg2zn2bbf.execute-api.us-east-1.amazonaws.com/token'
   OidcUserInfoEndpoint: 'https://repo-prod.prod.sagebase.org/auth/v1/oauth2/userinfo'
   OidcClientId: '100050'
+  SessionCookieName: 'AWSELBAuthSessionCookie'
   SessionTimeout: 3600
   KmsDecryptPolicyArn: !stack_output_external sc-kms-key::KmsDecryptPolicyArn
 ```

--- a/README.md
+++ b/README.md
@@ -185,7 +185,7 @@ parameters:
   OidcTokenEndpoint: 'https://qtg2zn2bbf.execute-api.us-east-1.amazonaws.com/token'
   OidcUserInfoEndpoint: 'https://repo-prod.prod.sagebase.org/auth/v1/oauth2/userinfo'
   OidcClientId: '100050'
-  SessionCookieName: 'AWSELBAuthSessionCookie'
+  SessionCookieNamePrefix: 'AWSELBAuthSessionCookie'
   SessionTimeout: 3600
   KmsDecryptPolicyArn: !stack_output_external sc-kms-key::KmsDecryptPolicyArn
 ```

--- a/ruler/app.py
+++ b/ruler/app.py
@@ -107,7 +107,7 @@ def create(event, context):
 
   # get variables from lambda properties and environment
   instance_id, target_group_arn, listener_arn = get_properties(event)
-  oidc_client_secret_key_name, oidc_issuer, oidc_auth_endpoint, oidc_token_endpoint,
+  oidc_client_secret_key_name, oidc_issuer, oidc_auth_endpoint, oidc_token_endpoint, \
   oidc_user_info_endpoint, oidc_client_id, session_cookie_name, session_timeout  = get_envvars()
 
   # get oidc client secret from ssm

--- a/ruler/app.py
+++ b/ruler/app.py
@@ -49,6 +49,7 @@ def get_envvars():
     'OIDC_TOKEN_ENDPOINT',
     'OIDC_USER_INFO_ENDPOINT',
     'OIDC_CLIENT_ID',
+    'SESSION_COOKIE_NAME',
     'SESSION_TIMEOUT'
   ]
   return get_variables(os.getenv, env_var_names, MISSING_ENVIRONMENT_VARIABLE_MESSAGE)
@@ -106,7 +107,8 @@ def create(event, context):
 
   # get variables from lambda properties and environment
   instance_id, target_group_arn, listener_arn = get_properties(event)
-  oidc_client_secret_key_name, oidc_issuer, oidc_auth_endpoint, oidc_token_endpoint, oidc_user_info_endpoint, oidc_client_id, session_timeout  = get_envvars()
+  oidc_client_secret_key_name, oidc_issuer, oidc_auth_endpoint, oidc_token_endpoint,
+  oidc_user_info_endpoint, oidc_client_id, session_cookie_name, session_timeout  = get_envvars()
 
   # get oidc client secret from ssm
   client_secret = get_client_key(oidc_client_secret_key_name)
@@ -143,6 +145,7 @@ def create(event, context):
               "claims": "{\"id_token\":{\"userid\":{\"essential\":true}},\"userinfo\":{\"userid\":{\"essential\":true}}}"
             },
             "OnUnauthenticatedRequest": "authenticate",
+            "SessionCookieName": session_cookie_name,
             "SessionTimeout": int(session_timeout)
           },
           "Order": 1

--- a/ruler/app.py
+++ b/ruler/app.py
@@ -49,7 +49,7 @@ def get_envvars():
     'OIDC_TOKEN_ENDPOINT',
     'OIDC_USER_INFO_ENDPOINT',
     'OIDC_CLIENT_ID',
-    'SESSION_COOKIE_NAME',
+    'SESSION_COOKIE_NAME_PREFIX',
     'SESSION_TIMEOUT'
   ]
   return get_variables(os.getenv, env_var_names, MISSING_ENVIRONMENT_VARIABLE_MESSAGE)
@@ -108,7 +108,7 @@ def create(event, context):
   # get variables from lambda properties and environment
   instance_id, target_group_arn, listener_arn = get_properties(event)
   oidc_client_secret_key_name, oidc_issuer, oidc_auth_endpoint, oidc_token_endpoint, \
-  oidc_user_info_endpoint, oidc_client_id, session_cookie_name, session_timeout  = get_envvars()
+  oidc_user_info_endpoint, oidc_client_id, session_cookie_name_prefix, session_timeout  = get_envvars()
 
   # get oidc client secret from ssm
   client_secret = get_client_key(oidc_client_secret_key_name)
@@ -145,7 +145,7 @@ def create(event, context):
               "claims": "{\"id_token\":{\"userid\":{\"essential\":true}},\"userinfo\":{\"userid\":{\"essential\":true}}}"
             },
             "OnUnauthenticatedRequest": "authenticate",
-            "SessionCookieName": session_cookie_name,
+            "SessionCookieName": f"{session_cookie_name_prefix}-{instance_id}",
             "SessionTimeout": int(session_timeout)
           },
           "Order": 1

--- a/template.yaml
+++ b/template.yaml
@@ -25,13 +25,13 @@ Parameters:
   KmsDecryptPolicyArn:
     Description: 'The ARN of the KMS decryption policy'
     Type: String
-  SessionCookieName:
-    Description: 'The name of the cookie storing the user authentication information'
+  SessionCookieNamePrefix:
+    Description: 'The prefix of the name of the cookie storing the user authentication information'
     Type: String
   SessionTimeout:
     Description: 'The duration (in seconds) for which an access token is kept before retrieving a new one'
     Type: Number
-    Default: 3600
+    Default: 86400
 
 Globals:
   Function:
@@ -53,7 +53,7 @@ Resources:
           OIDC_TOKEN_ENDPOINT: !Ref OidcTokenEndpoint
           OIDC_USER_INFO_ENDPOINT: !Ref OidcUserInfoEndpoint
           OIDC_CLIENT_ID: !Ref OidcClientId
-          SESSION_COOKIE_NAME: !Ref SessionCookieName
+          SESSION_COOKIE_NAME_PREFIX: !Ref SessionCookieNamePrefix
           SESSION_TIMEOUT: !Ref SessionTimeout
 
   ALBListenerRuleFunctionRole:

--- a/template.yaml
+++ b/template.yaml
@@ -25,6 +25,9 @@ Parameters:
   KmsDecryptPolicyArn:
     Description: 'The ARN of the KMS decryption policy'
     Type: String
+  SessionCookieName:
+    Description: 'The name of the cookie storing the user authentication information'
+    Type: String
   SessionTimeout:
     Description: 'The duration (in seconds) for which an access token is kept before retrieving a new one'
     Type: Number
@@ -50,6 +53,7 @@ Resources:
           OIDC_TOKEN_ENDPOINT: !Ref OidcTokenEndpoint
           OIDC_USER_INFO_ENDPOINT: !Ref OidcUserInfoEndpoint
           OIDC_CLIENT_ID: !Ref OidcClientId
+          SESSION_COOKIE_NAME: !Ref SessionCookieName
           SESSION_TIMEOUT: !Ref SessionTimeout
 
   ALBListenerRuleFunctionRole:

--- a/tests/unit/test_create.py
+++ b/tests/unit/test_create.py
@@ -12,7 +12,7 @@ from ruler import app
 
 class TestCreate(unittest.TestCase):
 
-  mock_create_response = {"Rules":[{"RuleArn":"arn:aws:elasticloadbalancing:us-east-1:012345678901:listener-rule/app/sc135-poc/bf54cc972d64237b/8ad4c71091181c60/62caa6dfa73dbce8","Priority":"7","Conditions":[{"Field":"path-pattern","Values":["/i-049f8b7f35ef87673"],"PathPatternConfig":{"Values":["/i-049f8b7f35ef87673"]}}],"Actions":[{"Type":"forward","TargetGroupArn":"arn:aws:elasticloadbalancing:us-east-1:012345678901:targetgroup/TargetGroup-i-049f8b7f35ef87673/32ee340e330ca6e2","Order":2,"ForwardConfig":{"TargetGroups":[{"TargetGroupArn":"arn:aws:elasticloadbalancing:us-east-1:012345678901:targetgroup/TargetGroup-i-049f8b7f35ef87673/32ee340e330ca6e2","Weight":1}],"TargetGroupStickinessConfig":{"Enabled":False}}},{"Type":"authenticate-oidc","AuthenticateOidcConfig":{"Issuer":"https://repo-prod.prod.sagebase.org/auth/v1","AuthorizationEndpoint":"https://repo-prod.prod.sagebase.org/auth/v1","TokenEndpoint":"https://qtg2zn2bbf.execute-api.us-east-1.amazonaws.com/token","UserInfoEndpoint":"https://repo-prod.prod.sagebase.org/auth/v1/oauth2/userinfo","ClientId":"100050","SessionCookieName":"AWSELBAuthSessionCookie","Scope":"openid","SessionCookieName":"my-cookie","SessionTimeout":604800,"AuthenticationRequestExtraParams":{"claims":"{\"id_token\":{\"userid\":{\"essential\":true}},\"userinfo\":{\"userid\":{\"essential\":true}}}"},"OnUnauthenticatedRequest":"authenticate"},"Order":1}],"IsDefault":False}]}
+  mock_create_response = {"Rules":[{"RuleArn":"arn:aws:elasticloadbalancing:us-east-1:012345678901:listener-rule/app/sc135-poc/bf54cc972d64237b/8ad4c71091181c60/62caa6dfa73dbce8","Priority":"7","Conditions":[{"Field":"path-pattern","Values":["/i-049f8b7f35ef87673"],"PathPatternConfig":{"Values":["/i-049f8b7f35ef87673"]}}],"Actions":[{"Type":"forward","TargetGroupArn":"arn:aws:elasticloadbalancing:us-east-1:012345678901:targetgroup/TargetGroup-i-049f8b7f35ef87673/32ee340e330ca6e2","Order":2,"ForwardConfig":{"TargetGroups":[{"TargetGroupArn":"arn:aws:elasticloadbalancing:us-east-1:012345678901:targetgroup/TargetGroup-i-049f8b7f35ef87673/32ee340e330ca6e2","Weight":1}],"TargetGroupStickinessConfig":{"Enabled":False}}},{"Type":"authenticate-oidc","AuthenticateOidcConfig":{"Issuer":"https://repo-prod.prod.sagebase.org/auth/v1","AuthorizationEndpoint":"https://repo-prod.prod.sagebase.org/auth/v1","TokenEndpoint":"https://qtg2zn2bbf.execute-api.us-east-1.amazonaws.com/token","UserInfoEndpoint":"https://repo-prod.prod.sagebase.org/auth/v1/oauth2/userinfo","ClientId":"100050","SessionCookieName":"AWSELBAuthSessionCookie-i-049f8b7f35ef87673","Scope":"openid","SessionCookieName":"my-cookie","SessionTimeout":604800,"AuthenticationRequestExtraParams":{"claims":"{\"id_token\":{\"userid\":{\"essential\":true}},\"userinfo\":{\"userid\":{\"essential\":true}}}"},"OnUnauthenticatedRequest":"authenticate"},"Order":1}],"IsDefault":False}]}
   mock_properties = [
     'i-049f8b7f35ef87673',
     'arn:aws:elasticloadbalancing:us-east-1:012345678901:targetgroup/TargetGroup-i-049f8b7f35ef87673/32ee340e330ca6e2',
@@ -25,7 +25,7 @@ class TestCreate(unittest.TestCase):
     'token-endpoint',
     'user-info-endpoint',
     'client-id',
-    'my-cookie',
+    'my-cookie-prefix',
     '3600'
   ]
 

--- a/tests/unit/test_create.py
+++ b/tests/unit/test_create.py
@@ -12,7 +12,7 @@ from ruler import app
 
 class TestCreate(unittest.TestCase):
 
-  mock_create_response = {"Rules":[{"RuleArn":"arn:aws:elasticloadbalancing:us-east-1:012345678901:listener-rule/app/sc135-poc/bf54cc972d64237b/8ad4c71091181c60/62caa6dfa73dbce8","Priority":"7","Conditions":[{"Field":"path-pattern","Values":["/i-049f8b7f35ef87673"],"PathPatternConfig":{"Values":["/i-049f8b7f35ef87673"]}}],"Actions":[{"Type":"forward","TargetGroupArn":"arn:aws:elasticloadbalancing:us-east-1:012345678901:targetgroup/TargetGroup-i-049f8b7f35ef87673/32ee340e330ca6e2","Order":2,"ForwardConfig":{"TargetGroups":[{"TargetGroupArn":"arn:aws:elasticloadbalancing:us-east-1:012345678901:targetgroup/TargetGroup-i-049f8b7f35ef87673/32ee340e330ca6e2","Weight":1}],"TargetGroupStickinessConfig":{"Enabled":False}}},{"Type":"authenticate-oidc","AuthenticateOidcConfig":{"Issuer":"https://repo-prod.prod.sagebase.org/auth/v1","AuthorizationEndpoint":"https://repo-prod.prod.sagebase.org/auth/v1","TokenEndpoint":"https://qtg2zn2bbf.execute-api.us-east-1.amazonaws.com/token","UserInfoEndpoint":"https://repo-prod.prod.sagebase.org/auth/v1/oauth2/userinfo","ClientId":"100050","SessionCookieName":"AWSELBAuthSessionCookie","Scope":"openid","SessionTimeout":604800,"AuthenticationRequestExtraParams":{"claims":"{\"id_token\":{\"userid\":{\"essential\":true}},\"userinfo\":{\"userid\":{\"essential\":true}}}"},"OnUnauthenticatedRequest":"authenticate"},"Order":1}],"IsDefault":False}]}
+  mock_create_response = {"Rules":[{"RuleArn":"arn:aws:elasticloadbalancing:us-east-1:012345678901:listener-rule/app/sc135-poc/bf54cc972d64237b/8ad4c71091181c60/62caa6dfa73dbce8","Priority":"7","Conditions":[{"Field":"path-pattern","Values":["/i-049f8b7f35ef87673"],"PathPatternConfig":{"Values":["/i-049f8b7f35ef87673"]}}],"Actions":[{"Type":"forward","TargetGroupArn":"arn:aws:elasticloadbalancing:us-east-1:012345678901:targetgroup/TargetGroup-i-049f8b7f35ef87673/32ee340e330ca6e2","Order":2,"ForwardConfig":{"TargetGroups":[{"TargetGroupArn":"arn:aws:elasticloadbalancing:us-east-1:012345678901:targetgroup/TargetGroup-i-049f8b7f35ef87673/32ee340e330ca6e2","Weight":1}],"TargetGroupStickinessConfig":{"Enabled":False}}},{"Type":"authenticate-oidc","AuthenticateOidcConfig":{"Issuer":"https://repo-prod.prod.sagebase.org/auth/v1","AuthorizationEndpoint":"https://repo-prod.prod.sagebase.org/auth/v1","TokenEndpoint":"https://qtg2zn2bbf.execute-api.us-east-1.amazonaws.com/token","UserInfoEndpoint":"https://repo-prod.prod.sagebase.org/auth/v1/oauth2/userinfo","ClientId":"100050","SessionCookieName":"AWSELBAuthSessionCookie","Scope":"openid","SessionCookieName":"my-cookie","SessionTimeout":604800,"AuthenticationRequestExtraParams":{"claims":"{\"id_token\":{\"userid\":{\"essential\":true}},\"userinfo\":{\"userid\":{\"essential\":true}}}"},"OnUnauthenticatedRequest":"authenticate"},"Order":1}],"IsDefault":False}]}
   mock_properties = [
     'i-049f8b7f35ef87673',
     'arn:aws:elasticloadbalancing:us-east-1:012345678901:targetgroup/TargetGroup-i-049f8b7f35ef87673/32ee340e330ca6e2',
@@ -25,6 +25,7 @@ class TestCreate(unittest.TestCase):
     'token-endpoint',
     'user-info-endpoint',
     'client-id',
+    'my-cookie',
     '3600'
   ]
 

--- a/tests/unit/test_get_variables.py
+++ b/tests/unit/test_get_variables.py
@@ -41,7 +41,7 @@ class TestGetVariables(unittest.TestCase):
     'OIDC_TOKEN_ENDPOINT',
     'OIDC_USER_INFO_ENDPOINT',
     'OIDC_CLIENT_ID',
-    'SESSION_COOKIE_NAME',
+    'SESSION_COOKIE_NAME_PREFIX',
     'SESSION_TIMEOUT'
     ]
 

--- a/tests/unit/test_get_variables.py
+++ b/tests/unit/test_get_variables.py
@@ -41,6 +41,7 @@ class TestGetVariables(unittest.TestCase):
     'OIDC_TOKEN_ENDPOINT',
     'OIDC_USER_INFO_ENDPOINT',
     'OIDC_CLIENT_ID',
+    'SESSION_COOKIE_NAME',
     'SESSION_TIMEOUT'
     ]
 


### PR DESCRIPTION
In Service Catalog, multiple Notebook stacks share an ALB, each using `cfn-cr-alb-rule` to add its own listener to the ALB.   All listeners specify the same cookie name, which causes them to share the same cookie.  This causes a problem when different listeners specify different session durations (time outs) for the same cookie.  "Old" stacks use the default session duration of seven days, which causes those notebooks to hang on to an expired Synapse access token. "New" notebook incorporate a fix to use a shorter duration, but they "collide" with older stacks which have established the longer session duration and end up being broken too.  The solution is to make sure different stacks to use different cookies, "decoupling" them from each other.  We do this by allowing a cookie prefix and appending the instance id as a suffix.